### PR TITLE
fix id code validator nfe

### DIFF
--- a/src/main/java/ee/sk/mid/MidNationalIdentificationCodeValidator.java
+++ b/src/main/java/ee/sk/mid/MidNationalIdentificationCodeValidator.java
@@ -37,18 +37,22 @@ public class MidNationalIdentificationCodeValidator {
         if (idCode == null || idCode.length() != 11) {
             return false;
         }
-        int controlDigit = Integer.parseInt(idCode.substring(10));
-
-        if (controlDigit != calculateControlDigit(idCode)) {
-            return false;
-        }
-
         try {
-            getBirthDate(idCode);
-        } catch (DateTimeException ex) {
-            return false;
+          int controlDigit = Integer.parseInt(idCode.substring(10));
+  
+          if (controlDigit != calculateControlDigit(idCode)) {
+              return false;
+          }
+  
+          try {
+              getBirthDate(idCode);
+          } catch (DateTimeException ex) {
+              return false;
+          }
+          return true;
+        } catch (NumberFormatException e) {
+          return false;
         }
-        return true;
     }
 
     public static int calculateControlDigit(String idCode) {

--- a/src/test/java/ee/sk/mid/NationalIdentificationCodeValidatorTest.java
+++ b/src/test/java/ee/sk/mid/NationalIdentificationCodeValidatorTest.java
@@ -48,6 +48,20 @@ public class NationalIdentificationCodeValidatorTest {
 
         assertThat(isValid, is(false));
     }
+    
+    @Test
+    public void shouldConsiderInvalid_lengthMismatch() {
+        boolean isValid = MidNationalIdentificationCodeValidator.isValid("376050302993");
+
+        assertThat(isValid, is(false));
+    }
+    
+    @Test
+    public void shouldConsiderInvalid_notNumber() {
+        boolean isValid = MidNationalIdentificationCodeValidator.isValid("3760503029y");
+
+        assertThat(isValid, is(false));
+    }
 
     @Test
     public void shouldCalculateControlDigit() {


### PR DESCRIPTION
Inputing id code like 3760503029y would crash with nfe instead of gracefully reporting that the code is invalid. This fixes it.